### PR TITLE
Fix mobile process layout and iPad trust badges

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -606,6 +606,28 @@
     .summary_text {
         font-size: 0.95rem;
     }
+    .cf_process_step {
+        flex-direction: column;
+        align-items: flex-start;
+        padding-left: 0;
+    }
+
+    .cf_step_connector {
+        position: relative;
+        left: 0;
+        margin-bottom: 10px;
+    }
+
+    .cf_step_content {
+        width: 100%;
+    }
+
+    .cf_step-left::after,
+    .cf_step-right::after,
+    .cf_process_path::before,
+    .cf_process_path::after {
+        display: none;
+    }
 }
 
 @media (max-width: 576px) {
@@ -712,6 +734,28 @@
         width: 100%;
         padding: 15px;
         font-size: 1rem;
+    }
+    .cf_process_step {
+        flex-direction: column;
+        align-items: flex-start;
+        padding-left: 0;
+    }
+
+    .cf_step_connector {
+        position: relative;
+        left: 0;
+        margin-bottom: 10px;
+    }
+
+    .cf_step_content {
+        width: 100%;
+    }
+
+    .cf_step-left::after,
+    .cf_step-right::after,
+    .cf_process_path::before,
+    .cf_process_path::after {
+        display: none;
     }
 }
 
@@ -2660,6 +2704,11 @@ body {
     color: var(--color-blue-primary);
     margin-right: 5px;
     font-size: 1rem;
+}
+@media (min-width: 768px) and (max-width: 1024px) {
+    .trustbadges {
+        flex-wrap: wrap;
+    }
 }
 
 .wave-1 {


### PR DESCRIPTION
## Summary
- ensure collaboration steps use full width on mobile
- allow badges to wrap on iPad

## Testing
- `npm start` *(fails: server interrupted after verifying startup)*

------
https://chatgpt.com/codex/tasks/task_e_6841a44a346883218c46df2d7925cf16