### PR TITLE
Fix mobile process layout and iPad CTA heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -532,7 +532,11 @@
                     <div class="cta_wrapper animate-element">
                         <div class="cta_content">
                             <h2 class="cta_title">
-                                <span class="title-main">Transformez Votre Projet</span>
+                                <span class="title-main">
+                                    <span class="cta_word">Transformez</span>
+                                    <span class="cta_word">Votre</span>
+                                    <span class="cta_word">Projet</span>
+                                </span>
                                 <span class="title-accent">en Histoire Visuelle</span>
                             </h2>
                             <p class="cta_description">

--- a/styles.css
+++ b/styles.css
@@ -358,66 +358,6 @@
         font-size: 2.5rem;
     }
     
-    .cf_process_step {
-        margin-bottom: 20px;
-        padding-bottom: 0;
-    }
-    
-    .cf_process_path::before {
-        left: 30px;
-        width: 2px;
-        transform: none;
-    }
-    
-    .cf_process_path::after {
-        left: 30px;
-        transform: none;
-    }
-    
-    .cf_process_step {
-        flex-direction: row;
-        justify-content: flex-start;
-        padding-left: 60px;
-    }
-    
-    .cf_step_content {
-        width: calc(100% - 60px);
-    }
-    
-    .cf_step-left, .cf_step-right {
-        justify-content: flex-start;
-    }
-    
-    .cf_step_number {
-        left: 15px !important;
-        right: auto !important;
-    }
-    
-    .cf_step_connector {
-        position: absolute;
-        left: 0;
-    }
-    
-    .cf_step-left::after, .cf_step-right::after {
-        content: '';
-        position: absolute;
-        height: 2px;
-        width: 30px;
-        left: 30px;
-        top: 40px;
-        background: var(--color-blue-primary);
-        z-index: 1;
-    }
-    
-    .cf_step_icon {
-        width: 60px;
-        height: 60px;
-        margin: 0;
-    }
-    
-    .cf_step_icon i {
-        font-size: 1.8rem;
-    }
 
     .cta_section {
         padding: 70px 0;

--- a/styles.css
+++ b/styles.css
@@ -685,22 +685,17 @@
         padding-left: 0;
         padding-right: 0;
     }
-    
-    .cf_process_step {
-        padding-left: 50px;
-    }
-    
+
     .cf_step_icon {
         width: 45px;
         height: 45px;
     }
-    
+
     .cf_step_icon i {
         font-size: 1.4rem;
     }
-    
+
     .cf_step_content {
-        width: calc(100% - 40px);
         padding: 15px;
     }
     

--- a/styles.css
+++ b/styles.css
@@ -606,33 +606,6 @@
     .summary_text {
         font-size: 0.95rem;
     }
-    .cf_process_step {
-        flex-direction: column;
-        align-items: stretch;
-        padding-left: 0;
-        margin-bottom: 30px;
-    }
-
-    .cf_process_step:last-child {
-        margin-bottom: 0;
-    }
-
-    .cf_step_connector {
-        position: relative;
-        left: 0;
-        margin: 0 auto 10px;
-    }
-
-    .cf_step_content {
-        width: 100%;
-    }
-
-    .cf_step-left::after,
-    .cf_step-right::after,
-    .cf_process_path::before,
-    .cf_process_path::after {
-        display: none;
-    }
 }
 
 @media (max-width: 576px) {
@@ -740,32 +713,6 @@
         padding: 15px;
         font-size: 1rem;
     }
-    .cf_process_step {
-        flex-direction: column;
-        align-items: stretch;
-        padding-left: 0;
-        margin-bottom: 30px;
-    }
-
-    .cf_process_step:last-child {
-        margin-bottom: 0;
-    }
-
-    .cf_step_connector {
-        position: relative;
-        left: 0;
-        margin: 0 auto 10px;
-    }
-
-    .cf_step_content {
-        width: 100%;
-    }
-
-    .cf_step-left::after,
-    .cf_step-right::after,
-    .cf_process_path::before,
-    .cf_process_path::after {
-        display: none;
     }
 }
 
@@ -2735,6 +2682,7 @@ body {
         margin-bottom: 30px;
         padding-left: 0;
         padding-bottom: 0;
+        width: 100%;
     }
 
     .cf_process_step:last-child {

--- a/styles.css
+++ b/styles.css
@@ -2733,6 +2733,44 @@ body {
     }
 }
 
+@media (max-width: 991px) {
+    .cf_process_step {
+        flex-direction: column;
+        align-items: stretch;
+        margin-bottom: 30px;
+        padding-left: 0;
+        padding-bottom: 0;
+    }
+
+    .cf_process_step:last-child {
+        margin-bottom: 0;
+    }
+
+    .cf_step_connector {
+        position: relative;
+        left: 0;
+        margin: 0 auto 10px;
+    }
+
+    .cf_step_content {
+        width: 100%;
+    }
+
+    .cf_step-left::after,
+    .cf_step-right::after,
+    .cf_process_path::before,
+    .cf_process_path::after {
+        display: none;
+    }
+}
+
+@media (max-width: 576px) {
+    .cf_process_section .container {
+        padding-left: 0;
+        padding-right: 0;
+    }
+}
+
 .wave-1 {
     position: absolute;
     bottom: 0;

--- a/styles.css
+++ b/styles.css
@@ -606,6 +606,33 @@
     .summary_text {
         font-size: 0.95rem;
     }
+    .cf_process_step {
+        flex-direction: column;
+        align-items: stretch;
+        padding-left: 0;
+        margin-bottom: 30px;
+    }
+
+    .cf_process_step:last-child {
+        margin-bottom: 0;
+    }
+
+    .cf_step_connector {
+        position: relative;
+        left: 0;
+        margin: 0 auto 10px;
+    }
+
+    .cf_step_content {
+        width: 100%;
+    }
+
+    .cf_step-left::after,
+    .cf_step-right::after,
+    .cf_process_path::before,
+    .cf_process_path::after {
+        display: none;
+    }
 }
 
 @media (max-width: 576px) {
@@ -652,6 +679,11 @@
     .cf_process_path::after {
         left: 25px;
         width: 2px;
+    }
+
+    .cf_process_section .container {
+        padding-left: 0;
+        padding-right: 0;
     }
     
     .cf_process_step {
@@ -712,6 +744,33 @@
         width: 100%;
         padding: 15px;
         font-size: 1rem;
+    }
+    .cf_process_step {
+        flex-direction: column;
+        align-items: stretch;
+        padding-left: 0;
+        margin-bottom: 30px;
+    }
+
+    .cf_process_step:last-child {
+        margin-bottom: 0;
+    }
+
+    .cf_step_connector {
+        position: relative;
+        left: 0;
+        margin: 0 auto 10px;
+    }
+
+    .cf_step_content {
+        width: 100%;
+    }
+
+    .cf_step-left::after,
+    .cf_step-right::after,
+    .cf_process_path::before,
+    .cf_process_path::after {
+        display: none;
     }
 }
 
@@ -2330,6 +2389,10 @@ body {
     opacity: 1;
 }
 
+.cta_word {
+    display: inline;
+}
+
 .cta_title .title-accent {
     display: inline-block;
     position: relative;
@@ -2660,6 +2723,14 @@ body {
     color: var(--color-blue-primary);
     margin-right: 5px;
     font-size: 1rem;
+}
+@media (min-width: 768px) and (max-width: 1024px) {
+    .trustbadges {
+        flex-wrap: wrap;
+    }
+    .cta_word {
+        display: block;
+    }
 }
 
 .wave-1 {


### PR DESCRIPTION
## Summary
- expand process steps and icons on mobile
- remove container padding for full-width cards
- break CTA heading words on iPad
- allow wrapping of trust badges on iPad

## Testing
- `npm start` *(server running on port 3000)*

------
https://chatgpt.com/codex/tasks/task_e_6841a44a346883218c46df2d7925cf16