### PR TITLE
Fix mobile CTA layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -534,7 +534,7 @@
                             <h2 class="cta_title">
                                 <span class="title-main">
                                     <span class="cta_word">Transformez</span>
-                                    <span class="cta_word">Votre</span>
+                                    <span class="cta_word">Votre</span><br class="mobile-break">
                                     <span class="cta_word">Projet</span>
                                 </span>
                                 <span class="title-accent">en Histoire Visuelle</span>

--- a/styles.css
+++ b/styles.css
@@ -687,6 +687,15 @@
         font-size: 1rem;
     }
 
+    /* Ajout pour adapter l'affichage du titre CTA sur mobile */
+    .cta_word {
+        display: block;
+    }
+
+    .cta_content {
+        text-align: center;
+    }
+
 
     .cf_process_step {
         flex-direction: column;
@@ -730,6 +739,17 @@
 .img-fluid {
     max-width: 100%;
     height: auto;
+}
+
+/* Saut de ligne activé uniquement sur mobile */
+.mobile-break {
+    display: none;
+}
+
+@media (max-width: 576px) {
+    .mobile-break {
+        display: block;
+    }
 }
 
 /* ===== CORRECTIONS SPÉCIFIQUES ===== */


### PR DESCRIPTION
## Summary
- tweak CTA text markup and CSS for mobile line breaks
- ensure CTA heading centered on small screens

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6841d6ccbb108321afa77672b7608957