### PR TITLE
Fix mobile CTA layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -534,7 +534,7 @@
                             <h2 class="cta_title">
                                 <span class="title-main">
                                     <span class="cta_word">Transformez</span>
-                                    <span class="cta_word">Votre</span>
+                                    <span class="cta_word">Votre</span><br class="mobile-break">
                                     <span class="cta_word">Projet</span>
                                 </span>
                                 <span class="title-accent">en Histoire Visuelle</span>

--- a/styles.css
+++ b/styles.css
@@ -686,6 +686,15 @@
         padding: 15px;
         font-size: 1rem;
     }
+    /* Ajout pour adapter l'affichage du titre CTA sur mobile */
+    .cta_word {
+        display: block;
+    }
+
+    .cta_content {
+        text-align: center;
+    }
+
 
 
     .cf_process_step {
@@ -731,6 +740,17 @@
     max-width: 100%;
     height: auto;
 }
+/* Saut de ligne activ uniquement sur mobile */
+.mobile-break {
+    display: none;
+}
+
+@media (max-width: 576px) {
+    .mobile-break {
+        display: block;
+    }
+}
+
 
 /* ===== CORRECTIONS SPÉCIFIQUES ===== */
 /* Assurer que les icônes Font Awesome s'affichent correctement */


### PR DESCRIPTION
## Summary
- tweak CTA text markup and CSS for mobile line breaks
- ensure CTA heading centered on small screens

## Testing
- `npm start`


------
https://chatgpt.com/codex/tasks/task_e_6841d6ccbb108321afa77672b7608957