### PR TITLE
Fix gradient header text visibility

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1776,6 +1776,8 @@ body {
     display: inline-block;
     background: linear-gradient(90deg, var(--color-dark) 0%, var(--color-dark) 50%, var(--color-blue-primary) 50%, var(--color-blue-primary) 100%);
     -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
     color: transparent;
     padding: 0 10px;
 }


### PR DESCRIPTION
## Summary
- ensure `.of_section_title` gradient text remains visible across browsers

## Testing
- `npm start` (server starts)

------
https://chatgpt.com/codex/tasks/task_e_6842942dc1a48321871f57da84d105ed